### PR TITLE
Removed [-Wparentheses-equality] warnings

### DIFF
--- a/src/cpp/f00251_fbos.h
+++ b/src/cpp/f00251_fbos.h
@@ -230,7 +230,7 @@ public:
 		if (isFloat) {
 
 
-			if ( (pixelsFloat == NULL) ) {
+			if (pixelsFloat == NULL) {
 				getPixels();
 			}
 
@@ -344,7 +344,7 @@ public:
 	int getPixelAtC(int x, int y, int channel) {
 
 		if (!isFloat) {
-			if ( (pixelsChar == NULL) ) {
+			if ( pixelsChar == NULL ) {
 				getPixels();
 			}
 

--- a/src/cpp/f00325_uicomponent.hpp
+++ b/src/cpp/f00325_uicomponent.hpp
@@ -1218,7 +1218,7 @@ public:
 		}
 		
 		bool finalRes = wasHit||hitChild;
-		if ((state == GLUT_UP)) { //&&(wheelDelta==0.0f)
+		if (state == GLUT_UP) { //&&(wheelDelta==0.0f)
 			wasHit = false;
 		}
 		
@@ -1558,10 +1558,7 @@ public:
 				// render a space
 				
 				curChar = ' ';
-				if (
-					//(i == wordVec.size()-1) && 
-					(j == wordVec[i].size()-1)
-				) {
+				if (j == wordVec[i].size()-1) {
 					//end of line, no space
 				}
 				else {

--- a/src/cpp/f00352_gameblock.hpp
+++ b/src/cpp/f00352_gameblock.hpp
@@ -1505,7 +1505,7 @@ public:
 											
 											
 											
-											if ( (curDir==1) ) { // 
+											if (curDir==1) { // 
 												
 												if (curBT == E_CT_DOORWAY) {
 													


### PR DESCRIPTION
Double parenthesis usually indicate an assignment which causes [-Wparentheses-equality] warning. Removed some of the unnecessary parenthesis.
